### PR TITLE
Add canonical url and robots to fix search console errors

### DIFF
--- a/apps/avowed-web/src/app/maps/[map]/page.tsx
+++ b/apps/avowed-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/avowed-web/src/app/maps/[map]/page.tsx
+++ b/apps/avowed-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,8 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
+
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/avowed-web/src/app/robots.txt
+++ b/apps/avowed-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/chrono-odyssey-web/src/app/maps/[map]/page.tsx
+++ b/apps/chrono-odyssey-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/chrono-odyssey-web/src/app/maps/[map]/page.tsx
+++ b/apps/chrono-odyssey-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,8 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
+
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/chrono-odyssey-web/src/app/robots.txt
+++ b/apps/chrono-odyssey-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/diablo4-web/src/app/robots.txt
+++ b/apps/diablo4-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/dune-awakening-web/src/app/maps/[map]/page.tsx
+++ b/apps/dune-awakening-web/src/app/maps/[map]/page.tsx
@@ -32,10 +32,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/dune-awakening-web/src/app/maps/[map]/page.tsx
+++ b/apps/dune-awakening-web/src/app/maps/[map]/page.tsx
@@ -17,15 +17,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -39,7 +39,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/dune-awakening-web/src/app/robots.txt
+++ b/apps/dune-awakening-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/hogwarts-legacy-web/src/app/robots.txt
+++ b/apps/hogwarts-legacy-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/infinity-nikki-web/src/app/maps/[map]/page.tsx
+++ b/apps/infinity-nikki-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/infinity-nikki-web/src/app/maps/[map]/page.tsx
+++ b/apps/infinity-nikki-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/infinity-nikki-web/src/app/robots.txt
+++ b/apps/infinity-nikki-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/night-crows-web/src/app/robots.txt
+++ b/apps/night-crows-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/once-human-web/src/app/robots.txt
+++ b/apps/once-human-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/palia-web/src/app/maps/[map]/page.tsx
+++ b/apps/palia-web/src/app/maps/[map]/page.tsx
@@ -32,10 +32,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/palia-web/src/app/maps/[map]/page.tsx
+++ b/apps/palia-web/src/app/maps/[map]/page.tsx
@@ -17,15 +17,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -39,7 +39,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/palia-web/src/app/robots.txt
+++ b/apps/palia-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/palworld-web/src/app/maps/[map]/page.tsx
+++ b/apps/palworld-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/palworld-web/src/app/maps/[map]/page.tsx
+++ b/apps/palworld-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/palworld-web/src/app/robots.txt
+++ b/apps/palworld-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/pax-dei-web/src/app/robots.txt
+++ b/apps/pax-dei-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/pillars-of-eternity-web/src/app/robots.txt
+++ b/apps/pillars-of-eternity-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/rsdragonwilds-web/src/app/maps/[map]/page.tsx
+++ b/apps/rsdragonwilds-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/rsdragonwilds-web/src/app/maps/[map]/page.tsx
+++ b/apps/rsdragonwilds-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/rsdragonwilds-web/src/app/robots.txt
+++ b/apps/rsdragonwilds-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/satisfactory-web/src/app/robots.txt
+++ b/apps/satisfactory-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/stormgate-web/src/app/robots.txt
+++ b/apps/stormgate-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/

--- a/apps/wuthering-waves-web/src/app/maps/[map]/page.tsx
+++ b/apps/wuthering-waves-web/src/app/maps/[map]/page.tsx
@@ -31,10 +31,18 @@ export async function generateMetadata({
     description += "locations, points of interest, and more.";
   }
 
-  return {
+  const result: Metadata = {
     title,
     description,
   };
+
+  if (process.env.VERCEL_URL) {
+    const baseUrl = `https://${process.env.VERCEL_URL}`;
+    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    result.alternates = { canonical: canonicalUrl };
+  }
+
+  return result;
 }
 
 export default async function Map({ params }: PageProps) {

--- a/apps/wuthering-waves-web/src/app/maps/[map]/page.tsx
+++ b/apps/wuthering-waves-web/src/app/maps/[map]/page.tsx
@@ -16,15 +16,15 @@ interface PageProps {
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
-  let map = (await params).map;
-  map = decodeURIComponent(map);
-  if (!map.endsWith(" Map")) {
-    map += " Map";
+  const map = (await params).map;
+  let decodedMap = decodeURIComponent(map);
+  if (!decodedMap.endsWith(" Map")) {
+    decodedMap += " Map";
   }
 
-  const title = `${map} – ${APP_CONFIG.title} Interactive Map`;
+  const title = `${decodedMap} – ${APP_CONFIG.title} Interactive Map`;
 
-  let description = `Explore ${map} in ${APP_CONFIG.title} with `;
+  let description = `Explore ${decodedMap} in ${APP_CONFIG.title} with `;
   if (APP_CONFIG.keywords) {
     description += `${APP_CONFIG.keywords.join(", ")}, plus more locations.`;
   } else {
@@ -38,7 +38,7 @@ export async function generateMetadata({
 
   if (process.env.VERCEL_URL) {
     const baseUrl = `https://${process.env.VERCEL_URL}`;
-    const canonicalUrl = `${baseUrl}/maps/${encodeURIComponent(map)}`;
+    const canonicalUrl = `${baseUrl}/maps/${map}`;
     result.alternates = { canonical: canonicalUrl };
   }
 

--- a/apps/wuthering-waves-web/src/app/robots.txt
+++ b/apps/wuthering-waves-web/src/app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /nodes/


### PR DESCRIPTION
## 📝 Description

Google search console reported 404 for /nodes requests, which shouldn't be requested at all.
In addition, there are some canonical issues if search params are added to the URLs.

## ✅ Changes

- [ ] Feature
- [x] Bugfix
- [ ] Refactor
- [ ] UI update
- [ ] Other (please describe):

## 🚀 What was added or changed?

- Add robots.txt to all relevant projects
- Add canonical url to /[map]/page.tsx

## 🔍 How to test it

Only possible on production, because it's reading the vercel env url. 